### PR TITLE
ci: Add supported targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,14 @@ jobs:
         # Configure QEMU
         QEMU_TARGETS=" \
           aarch64-softmmu \
+          arm-softmmu \
+          i386-softmmu \
+          nios2-softmmu \
+          riscv32-softmmu \
+          riscv64-softmmu \
+          sparc-softmmu \
+          x86_64-softmmu \
+          xtensa-softmmu \
         "
 
         QEMU_FLAGS=" \


### PR DESCRIPTION
This commit adds all targets supported by the Zephyr RTOS.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>