### PR TITLE
Makefile: Add Zephyr QEMU version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,10 @@ CONFIG_BLOCK := $(call lor,$(CONFIG_SOFTMMU),$(CONFIG_TOOLS))
 QEMU_PKGVERSION := $(if $(PKGVERSION),$(PKGVERSION),$(shell \
   cd $(SRC_PATH); \
   if test -e .git; then \
-    git describe --match 'v*' 2>/dev/null | tr -d '\n'; \
+    echo -n "Zephyr QEMU "; \
+    git describe --match 'zephyr-qemu-v*' 2>/dev/null | tr -d '\n'; \
     if ! git diff-index --quiet HEAD &>/dev/null; then \
-      echo "-dirty"; \
+      echo -n "-dirty"; \
     fi; \
   fi))
 


### PR DESCRIPTION
This commit updates the Makefile to generate and use the Zephyr QEMU
version information string for the "package version" by default.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>