### PR TITLE
os-posix: Add default directory layout support to os_find_datadir

### DIFF
--- a/os-posix.c
+++ b/os-posix.c
@@ -98,6 +98,11 @@ char *os_find_datadir(void)
         return g_steal_pointer(&dir);
     }
 
+    dir = g_build_filename(exec_dir, "..", "share", "qemu", NULL);
+    if (g_file_test(dir, G_FILE_TEST_IS_DIR)) {
+        return g_steal_pointer(&dir);
+    }
+
     return g_strdup(CONFIG_QEMU_DATADIR);
 }
 


### PR DESCRIPTION
The `os_find_datadir` function currently supports locating the relative
path of the data directory only in the build tree (i.e. `../pc-bios`).

In order to allow the installed QEMU executables to be relocatable, it
necessary to specify an alternate relative path based on the default
POSIX QEMU installation directory layout, in which the data directory
is located at `../share/qemu`.

This effectively eliminates the need for specifying the `-L` parameter
when the QEMU executables are relocated.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>