### PR TITLE
Makefile: Fix version information display issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
 
         if [ "${{ matrix.host.name }}" == "windows-x86_64" ]; then
           QEMU_FLAGS="${QEMU_FLAGS} \
-            --cross-prefix="x86_64-w64-mingw32-"
+            --cross-prefix=x86_64-w64-mingw32-
           "
         fi
 

--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,7 @@ QEMU_PKGVERSION := $(if $(PKGVERSION),$(PKGVERSION),$(shell \
   cd $(SRC_PATH); \
   if test -e .git; then \
     git describe --match 'zephyr-qemu-v*' 2>/dev/null | tr -d '\n'; \
-    if ! git diff-index --quiet HEAD &>/dev/null; then \
-      echo "-dirty"; \
-    fi; \
+    git diff --quiet 2>/dev/null || echo '-dirty'; \
   fi))
 
 # Either "version (pkgversion)", or just "version" if pkgversion not set

--- a/Makefile
+++ b/Makefile
@@ -95,10 +95,9 @@ CONFIG_BLOCK := $(call lor,$(CONFIG_SOFTMMU),$(CONFIG_TOOLS))
 QEMU_PKGVERSION := $(if $(PKGVERSION),$(PKGVERSION),$(shell \
   cd $(SRC_PATH); \
   if test -e .git; then \
-    echo -n "Zephyr QEMU "; \
     git describe --match 'zephyr-qemu-v*' 2>/dev/null | tr -d '\n'; \
     if ! git diff-index --quiet HEAD &>/dev/null; then \
-      echo -n "-dirty"; \
+      echo "-dirty"; \
     fi; \
   fi))
 


### PR DESCRIPTION
Since the tag name already includes the `zephyr-qemu-` prefix, the
"Zephyr QEMU" string at the beginning of the version information is
redundant.

Also, `echo -n` does not behave correctly when building on macOS and
results in `-n` being included in the version information string.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

**TODO**
- [x] Verify that version information is properly displayed on Linux
- [x] Verify that version information is properly displayed on macOS
- [x] Verify that version information is properly displayed on Windows