### PR TITLE
ARC: Fix icount support

### DIFF
--- a/target/arc/arc-semfunc.c
+++ b/target/arc/arc-semfunc.c
@@ -4069,6 +4069,7 @@ arc2_gen_AEX (DisasCtxt *ctx, TCGv src2, TCGv b)
 
 
 
+#include "exec/gen-icount.h"
 
 
 /* LR
@@ -4084,6 +4085,10 @@ int
 arc2_gen_LR (DisasCtxt *ctx, TCGv dest, TCGv src)
 {
   int ret = DISAS_NEXT;
+
+  if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT)
+    gen_io_start();
+
   TCGv temp_1 = tcg_temp_local_new_i32();
   readAuxReg(temp_1, src);
   tcg_gen_mov_i32(dest, temp_1);
@@ -4109,6 +4114,9 @@ int
 arc2_gen_SR (DisasCtxt *ctx, TCGv src2, TCGv src1)
 {
   int ret = DISAS_NEXT;
+
+  if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT)
+    gen_io_start();
 
   writeAuxReg(src2, src1);
   return ret;


### PR DESCRIPTION
Looks like we have everything in place for using icount except
we don't take care about I/O.

Given writes to AUX register:
 a) May lead to IRQ (if we change ARC Timer LIMIT or COUNT regs)
 b) Via ARc Timers interact with host's time
 b) Anyways are often used to access some kind of peripherals or even
    specific ARC internals which might be treated as I/O

Let's mark TB's where we execute LR/SR instructions as possible I/O.

Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>

cc @abrodkin